### PR TITLE
fix get_delay to get_delay_steps, based on https://github.com/nest/nest-simulator/issues/1025

### DIFF
--- a/GlifModel/glif_lif.cpp
+++ b/GlifModel/glif_lif.cpp
@@ -214,7 +214,7 @@ void nest::glif_lif::update(Time const &origin, const long from,
 }
 
 void nest::glif_lif::handle(SpikeEvent &e) {
-  assert(e.get_delay() > 0);
+  assert(e.get_delay_steps() > 0);
 
   B_.spikes_.add_value(
       e.get_rel_delivery_steps(kernel().simulation_manager.get_slice_origin()),
@@ -222,7 +222,7 @@ void nest::glif_lif::handle(SpikeEvent &e) {
 }
 
 void nest::glif_lif::handle(CurrentEvent &e) {
-  assert(e.get_delay() > 0);
+  assert(e.get_delay_steps() > 0);
 
   B_.currents_.add_value(
       e.get_rel_delivery_steps(kernel().simulation_manager.get_slice_origin()),

--- a/GlifModel/glif_lif_asc.cpp
+++ b/GlifModel/glif_lif_asc.cpp
@@ -293,7 +293,7 @@ nest::glif_lif_asc::update( Time const& origin, const long from, const long to )
 void
 nest::glif_lif_asc::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -303,7 +303,7 @@ nest::glif_lif_asc::handle( SpikeEvent& e )
 void
 nest::glif_lif_asc::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_asc_cond.cpp
+++ b/GlifModel/glif_lif_asc_cond.cpp
@@ -535,7 +535,7 @@ nest::glif_lif_asc_cond::handles_test_event( SpikeEvent&,
 void
 nest::glif_lif_asc_cond::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[e.get_rport() - 1].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -545,7 +545,7 @@ nest::glif_lif_asc_cond::handle( SpikeEvent& e )
 void
 nest::glif_lif_asc_cond::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_asc_psc.cpp
+++ b/GlifModel/glif_lif_asc_psc.cpp
@@ -387,7 +387,7 @@ nest::glif_lif_asc_psc::handles_test_event( SpikeEvent&,
 void
 nest::glif_lif_asc_psc::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[e.get_rport() - 1].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -397,7 +397,7 @@ nest::glif_lif_asc_psc::handle( SpikeEvent& e )
 void
 nest::glif_lif_asc_psc::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_cond.cpp
+++ b/GlifModel/glif_lif_cond.cpp
@@ -505,7 +505,7 @@ nest::glif_lif_cond::handles_test_event( SpikeEvent&,
 void
 nest::glif_lif_cond::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[e.get_rport() - 1].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -515,7 +515,7 @@ nest::glif_lif_cond::handle( SpikeEvent& e )
 void
 nest::glif_lif_cond::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_psc.cpp
+++ b/GlifModel/glif_lif_psc.cpp
@@ -363,7 +363,7 @@ nest::glif_lif_psc::handles_test_event( SpikeEvent&,
 void
 nest::glif_lif_psc::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[e.get_rport() - 1].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -373,7 +373,7 @@ nest::glif_lif_psc::handle( SpikeEvent& e )
 void
 nest::glif_lif_psc::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_r.cpp
+++ b/GlifModel/glif_lif_r.cpp
@@ -282,7 +282,7 @@ nest::glif_lif_r::update( Time const& origin, const long from, const long to )
 void
 nest::glif_lif_r::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -292,7 +292,7 @@ nest::glif_lif_r::handle( SpikeEvent& e )
 void
 nest::glif_lif_r::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_r_asc.cpp
+++ b/GlifModel/glif_lif_r_asc.cpp
@@ -319,7 +319,7 @@ nest::glif_lif_r_asc::update( Time const& origin, const long from, const long to
 void
 nest::glif_lif_r_asc::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -329,7 +329,7 @@ nest::glif_lif_r_asc::handle( SpikeEvent& e )
 void
 nest::glif_lif_r_asc::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_r_asc_a.cpp
+++ b/GlifModel/glif_lif_r_asc_a.cpp
@@ -352,7 +352,7 @@ nest::glif_lif_r_asc_a::update( Time const& origin, const long from, const long 
 void
 nest::glif_lif_r_asc_a::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -362,7 +362,7 @@ nest::glif_lif_r_asc_a::handle( SpikeEvent& e )
 void
 nest::glif_lif_r_asc_a::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_r_asc_a_cond.cpp
+++ b/GlifModel/glif_lif_r_asc_a_cond.cpp
@@ -593,7 +593,7 @@ nest::glif_lif_r_asc_a_cond::handles_test_event( SpikeEvent&,
 void
 nest::glif_lif_r_asc_a_cond::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[e.get_rport() - 1].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -603,7 +603,7 @@ nest::glif_lif_r_asc_a_cond::handle( SpikeEvent& e )
 void
 nest::glif_lif_r_asc_a_cond::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_r_asc_a_psc.cpp
+++ b/GlifModel/glif_lif_r_asc_a_psc.cpp
@@ -451,7 +451,7 @@ nest::glif_lif_r_asc_a_psc::handles_test_event( SpikeEvent&,
 void
 nest::glif_lif_r_asc_a_psc::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[e.get_rport() - 1].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -461,7 +461,7 @@ nest::glif_lif_r_asc_a_psc::handle( SpikeEvent& e )
 void
 nest::glif_lif_r_asc_a_psc::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_r_asc_cond.cpp
+++ b/GlifModel/glif_lif_r_asc_cond.cpp
@@ -569,7 +569,7 @@ nest::glif_lif_r_asc_cond::handles_test_event( SpikeEvent&,
 void
 nest::glif_lif_r_asc_cond::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[e.get_rport() - 1].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -579,7 +579,7 @@ nest::glif_lif_r_asc_cond::handle( SpikeEvent& e )
 void
 nest::glif_lif_r_asc_cond::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_r_asc_psc.cpp
+++ b/GlifModel/glif_lif_r_asc_psc.cpp
@@ -416,7 +416,7 @@ nest::glif_lif_r_asc_psc::handles_test_event( SpikeEvent&,
 void
 nest::glif_lif_r_asc_psc::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[e.get_rport() - 1].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -426,7 +426,7 @@ nest::glif_lif_r_asc_psc::handle( SpikeEvent& e )
 void
 nest::glif_lif_r_asc_psc::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_r_cond.cpp
+++ b/GlifModel/glif_lif_r_cond.cpp
@@ -526,7 +526,7 @@ nest::glif_lif_r_cond::handles_test_event( SpikeEvent&,
 void
 nest::glif_lif_r_cond::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[e.get_rport() - 1].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -536,7 +536,7 @@ nest::glif_lif_r_cond::handle( SpikeEvent& e )
 void
 nest::glif_lif_r_cond::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),

--- a/GlifModel/glif_lif_r_psc.cpp
+++ b/GlifModel/glif_lif_r_psc.cpp
@@ -376,7 +376,7 @@ nest::glif_lif_r_psc::handles_test_event( SpikeEvent&,
 void
 nest::glif_lif_r_psc::handle( SpikeEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.spikes_[e.get_rport() - 1].add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),
@@ -386,7 +386,7 @@ nest::glif_lif_r_psc::handle( SpikeEvent& e )
 void
 nest::glif_lif_r_psc::handle( CurrentEvent& e )
 {
-  assert( e.get_delay() > 0 );
+  assert( e.get_delay_steps() > 0 );
 
   B_.currents_.add_value(
     e.get_rel_delivery_steps( kernel().simulation_manager.get_slice_origin() ),


### PR DESCRIPTION
Changed get_delay to get_delay_steps.
